### PR TITLE
Azure pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Note: cmake must be taken from the Windows installation!
 
 To build all:
 
-  buildall.bat -t <installation dir>
+  `buildall.bat -t <installation dir>`
 
 To build 32 bit only:
 
-  buildall.bat -32 ...
+  `buildall.bat -p 32 ...`

--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ To build "microbit" only (curl, expat, ptw, and zlib, but not python nor ruby):
 
 microbits:
 [ ![Download](https://api.bintray.com/packages/lightwave-lab/klayout/klayout-microbits/images/download.svg) ](https://bintray.com/lightwave-lab/klayout/klayout-microbits/_latestVersion)
+
+bits:
+[ ![Download](https://api.bintray.com/packages/lightwave-lab/klayout/klayout-bits/images/download.svg) ](https://bintray.com/lightwave-lab/klayout/klayout-bits/_latestVersion)

--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ To build all:
 To build 32 bit only:
 
   `buildall.bat -p 32 ...`
+
+To build "microbit" only (curl, expat, ptw, and zlib, but not python nor ruby):
+
+  `buildall.bat -only micro`
+
+# Latest release downloads:
+
+microbits:
+[ ![Download](https://api.bintray.com/packages/lightwave-lab/klayout/klayout-microbits/images/download.svg) ](https://bintray.com/lightwave-lab/klayout/klayout-microbits/_latestVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,6 @@
 # https://aka.ms/yaml
+variables:
+  version: '1.0'
 jobs:
 - job: build_all
   pool:
@@ -37,7 +39,7 @@ jobs:
       targetPath: 'klayout-bits-installed'
 
 - job: aggregate_micro
-  displayName: 'Aggregate KLayout microbits'
+  displayName: 'prepare klayout-microbits.zip'
   dependsOn: build_micro
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
@@ -46,20 +48,26 @@ jobs:
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: 'klayout-microbits-32'
-      targetPath: $(System.DefaultWorkingDirectory)
+      targetPath: $(System.DefaultWorkingDirectory)/klayout-microbits-$(version)
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: 'klayout-microbits-64'
-      targetPath: $(System.DefaultWorkingDirectory)
-  - bash: |
-      find .
+      targetPath: $(System.DefaultWorkingDirectory)/klayout-microbits-$(version)
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: '$(System.DefaultWorkingDirectory)/klayout-microbits-$(version)' 
+      includeRootFolder: true
+      archiveType: 'zip' # Options: zip, 7z, tar, wim
+      #tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+      archiveFile: 'klayout-microbits.zip' 
+      #replaceExistingArchive: true 
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: 'klayout-microbits'
-      targetPath: '$(System.DefaultWorkingDirectory)'
+      targetPath: $(System.DefaultWorkingDirectory)
 
 - job: aggregate_all
-  displayName: 'Aggregate KLayout bits'
+  displayName: 'prepare klayout-bits.zip'
   dependsOn: build_all
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
@@ -68,14 +76,20 @@ jobs:
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: 'klayout-allbits-32'
-      targetPath: $(System.DefaultWorkingDirectory)
+      targetPath: $(System.DefaultWorkingDirectory)/klayout-bits-$(version)
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: 'klayout-allbits-64'
-      targetPath: $(System.DefaultWorkingDirectory)
-  - bash: |
-      find .
+      targetPath: $(System.DefaultWorkingDirectory)/klayout-bits-$(version)
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: '$(System.DefaultWorkingDirectory)/klayout-bits-$(version)' 
+      includeRootFolder: true
+      archiveType: 'zip' # Options: zip, 7z, tar, wim
+      #tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+      archiveFile: 'klayout-bits.zip' 
+      #replaceExistingArchive: true 
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: 'klayout-bits'
-      targetPath: '$(System.DefaultWorkingDirectory)'
+      targetPath: $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
 - job: build_all
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 40
   strategy:
     matrix:
       x86-bits:
@@ -17,6 +17,10 @@ jobs:
     maxParallel: 2
   steps:
   - template: azure/buildtemplate.yml
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-$(build.set)bits-$(arch)'
+      targetPath: 'klayout-bits-installed'
 
 - job: build_micro
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,15 @@ jobs:
 
   steps:
   - script: |
-      pacman -S bison
-    displayName: 'Installing dependencies'
+      choco install msys2 --params="/InstallDir:%CD:~0,2%\msys64 /NoUpdate"
+    displayName: 'Installing msys2'
   - script: |
+      set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
+      echo %PATH%
+      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S bison
+      dir %CD:~0,2%\msys64\usr\bin
+    displayName: 'Installing bison'
+  - script: |
+      set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
       buildall.bat
     displayName: 'Build all bits'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,10 @@ jobs:
     maxParallel: 2
   steps:
   - template: azure/buildtemplate.yml
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-$(build.set)bits-$(arch)'
+      targetPath: 'klayout-bits-installed'
 
 - job: aggregate_micro
   displayName: 'Aggregate KLayout microbits'
@@ -41,9 +45,18 @@ jobs:
   - checkout: none
   - task: DownloadPipelineArtifact@0
     inputs:
+      artifactName: 'klayout-microbits-32'
+      targetPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-microbits-64'
       targetPath: $(System.DefaultWorkingDirectory)
   - bash: |
       find .
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-microbits'
+      targetPath: '$(System.DefaultWorkingDirectory)'
 
 - job: aggregate_all
   displayName: 'Aggregate KLayout bits'
@@ -54,6 +67,15 @@ jobs:
   - checkout: none
   - task: DownloadPipelineArtifact@0
     inputs:
+      artifactName: 'klayout-allbits-32'
+      targetPath: $(System.DefaultWorkingDirectory)
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-allbits-64'
       targetPath: $(System.DefaultWorkingDirectory)
   - bash: |
       find .
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-bits'
+      targetPath: '$(System.DefaultWorkingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,22 @@
 # https://aka.ms/yaml
 jobs:
-- job: Build
+- job: build_all
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  timeoutInMinutes: 120
+  strategy:
+    matrix:
+      x86-bits:
+        arch: '32'
+        build.set: 'all'
+      x64-bits:
+        arch: '64'
+        build.set: 'all'
+    maxParallel: 2
+  steps:
+  - template: azure/buildtemplate.yml
+
+- job: build_micro
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
   timeoutInMinutes: 120
@@ -12,36 +28,26 @@ jobs:
       x64-microbits:
         arch: '64'
         build.set: 'micro'
-      x86-bits:
-        arch: '32'
-        build.set: 'all'
-      x64-bits:
-        arch: '64'
-        build.set: 'all'
-    maxParallel: 4
+    maxParallel: 2
   steps:
-  - script: |
-      choco install msys2 --params="/InstallDir:%CD:~0,2%\msys64 /NoUpdate"
-    displayName: 'Install msys2'
-  - script: |
-      set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S bison flex
-    displayName: 'Install bison and flex'
-  - script: |
-      set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
-      echo ARCH=%ARCH%
-      echo BUILD_SET=%BUILD_SET%
-      buildall.bat -p %ARCH% -only %BUILD_SET% -t .\klayout-bits-installed
-    displayName: 'Build klayout-$(build.set)bits-$(arch)'
+  - template: azure/buildtemplate.yml
+
+- job: aggregate_micro
+  displayName: 'Aggregate KLayout microbits'
+  dependsOn: build_micro
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  steps:
+  - checkout: none
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)
   - bash: |
       find .
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'klayout-$(build.set)bits-$(arch)'
-      targetPath: 'klayout-bits-installed'
-- job: Aggregate
-  displayName: 'Aggregate KLayout bits together'
-  dependsOn: Build
+
+- job: aggregate_all
+  displayName: 'Aggregate KLayout bits'
+  dependsOn: build_all
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
 - job: build_micro
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 10
   strategy:
     matrix:
       x86-microbits:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+# https://aka.ms/yaml
+jobs:
+- job: Build
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+
+  steps:
+  - script: |
+      buildall.bat
+    displayName: 'Build all bits'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,5 +6,8 @@ jobs:
 
   steps:
   - script: |
+      pacman -S bison
+    displayName: 'Installing dependencies'
+  - script: |
       buildall.bat
     displayName: 'Build all bits'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,21 @@ jobs:
       echo BUILD_SET=%BUILD_SET%
       buildall.bat -p %ARCH% -only %BUILD_SET% -t .\klayout-bits-installed
     displayName: 'Build klayout-$(build.set)bits-$(arch)'
+  - bash: |
+      find .
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: 'klayout-$(build.set)bits-$(arch)'
       targetPath: 'klayout-bits-installed'
+- job: Aggregate
+  displayName: 'Aggregate KLayout bits together'
+  dependsOn: Build
+  pool:
+    vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  steps:
+  - checkout: none
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)
+  - bash: |
+      find .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,18 +3,23 @@ jobs:
 - job: Build
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
-
+  strategy:
+    matrix:
+      x86:
+        arch: 'x86'
+      x64:
+        arch: 'x64'
+    maxParallel: 2
   steps:
   - script: |
       choco install msys2 --params="/InstallDir:%CD:~0,2%\msys64 /NoUpdate"
-    displayName: 'Installing msys2'
+    displayName: 'Install msys2'
   - script: |
       set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
-      echo %PATH%
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S bison
-      dir %CD:~0,2%\msys64\usr\bin
-    displayName: 'Installing bison'
+      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S bison flex
+    displayName: 'Install bison and flex'
   - script: |
       set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
-      buildall.bat
-    displayName: 'Build all bits'
+      echo ARCH=%ARCH%
+      buildall.bat -p %ARCH%
+    displayName: 'Build $(arch) bits'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,13 +3,22 @@ jobs:
 - job: Build
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
+  timeoutInMinutes: 120
   strategy:
     matrix:
-      x86:
-        arch: 'x86'
-      x64:
-        arch: 'x64'
-    maxParallel: 2
+      x86-microbits:
+        arch: '32'
+        build.set: 'micro'
+      x64-microbits:
+        arch: '64'
+        build.set: 'micro'
+      x86-bits:
+        arch: '32'
+        build.set: 'all'
+      x64-bits:
+        arch: '64'
+        build.set: 'all'
+    maxParallel: 4
   steps:
   - script: |
       choco install msys2 --params="/InstallDir:%CD:~0,2%\msys64 /NoUpdate"
@@ -21,5 +30,10 @@ jobs:
   - script: |
       set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
       echo ARCH=%ARCH%
-      buildall.bat -p %ARCH%
-    displayName: 'Build $(arch) bits'
+      echo BUILD_SET=%BUILD_SET%
+      buildall.bat -p %ARCH% -only %BUILD_SET% -t .\klayout-bits-installed
+    displayName: 'Build klayout-$(build.set)bits-$(arch)'
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'klayout-$(build.set)bits-$(arch)'
+      targetPath: 'klayout-bits-installed'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       targetPath: 'klayout-bits-installed'
 
 - job: aggregate_micro
-  displayName: 'prepare klayout-microbits.zip'
+  displayName: 'prepare klayout-microbits-$(version).zip'
   dependsOn: build_micro
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
@@ -59,7 +59,7 @@ jobs:
       includeRootFolder: true
       archiveType: 'zip' # Options: zip, 7z, tar, wim
       #tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
-      archiveFile: 'klayout-microbits.zip' 
+      archiveFile: 'klayout-microbits-$(version).zip' 
       #replaceExistingArchive: true 
   - task: PublishPipelineArtifact@0
     inputs:
@@ -67,7 +67,7 @@ jobs:
       targetPath: $(System.DefaultWorkingDirectory)
 
 - job: aggregate_all
-  displayName: 'prepare klayout-bits.zip'
+  displayName: 'prepare klayout-bits-$(version).zip'
   dependsOn: build_all
   pool:
     vmImage: 'vs2017-win2016' # other options: 'macOS-10.13', 'ubuntu-16.04'
@@ -87,7 +87,7 @@ jobs:
       includeRootFolder: true
       archiveType: 'zip' # Options: zip, 7z, tar, wim
       #tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
-      archiveFile: 'klayout-bits.zip' 
+      archiveFile: 'klayout-bits-$(version).zip' 
       #replaceExistingArchive: true 
   - task: PublishPipelineArtifact@0
     inputs:

--- a/azure/buildtemplate.yml
+++ b/azure/buildtemplate.yml
@@ -1,0 +1,20 @@
+steps:
+- script: |
+    choco install msys2 --params="/InstallDir:%CD:~0,2%\msys64 /NoUpdate"
+  displayName: 'Install msys2'
+- script: |
+    set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
+    %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S bison flex
+  displayName: 'Install bison and flex'
+- script: |
+    set PATH=%CD:~0,2%\msys64\usr\bin;%PATH%
+    echo ARCH=%ARCH%
+    echo BUILD_SET=%BUILD_SET%
+    buildall.bat -p %ARCH% -only %BUILD_SET% -t %cd%\klayout-bits-installed
+  displayName: 'Build klayout-$(build.set)bits-$(arch)'
+- bash: |
+    find .
+- task: PublishPipelineArtifact@0
+  inputs:
+    artifactName: 'klayout-$(build.set)bits-$(arch)'
+    targetPath: 'klayout-bits-installed'

--- a/azure/buildtemplate.yml
+++ b/azure/buildtemplate.yml
@@ -12,9 +12,3 @@ steps:
     echo BUILD_SET=%BUILD_SET%
     buildall.bat -p %ARCH% -only %BUILD_SET% -t %cd%\klayout-bits-installed
   displayName: 'Build klayout-$(build.set)bits-$(arch)'
-- bash: |
-    find .
-- task: PublishPipelineArtifact@0
-  inputs:
-    artifactName: 'klayout-$(build.set)bits-$(arch)'
-    targetPath: 'klayout-bits-installed'

--- a/build.bat
+++ b/build.bat
@@ -7,8 +7,15 @@ set KLAYOUT_BITS_INST_PATH=%inst_path%
 set dest_dir=%3
 set arch=%1
 set kit=%2
+set only=%4
 
-for /d %%b in (%inst_path%bit_*) do (
+if "%only%" == "micro" (
+  set bit_list=%inst_path%bit_curl %inst_path%bit_expat %inst_path%bit_ptw %inst_path%bit_zlib
+) else (
+  set bit_list=%inst_path%bit_*
+)
+
+for /d %%b in (%bit_list%) do (
 
   echo -----------------------------------------------
 

--- a/buildall.bat
+++ b/buildall.bat
@@ -24,6 +24,7 @@ if defined option (
   echo   -t {target-dir}    Specify the target directory where to install the bits
   echo   -p 32              Builds 32bit. Default: all
   echo   -p 64              Builds 64bit. Default: all
+  echo   -only micro        Builds only the microbits
   echo.
   goto :eof
 )
@@ -41,6 +42,10 @@ if defined option-p (
   )
   if "%option-p%" == "64" (
     set option-64=1
+  )
+  if "%option-p%" neq "32" if "%option-p%" neq "64" (
+    echo ERROR: Unknown option -p: %option-p%
+    goto :eof
   )
 ) else (
   set option-32=1

--- a/buildall.bat
+++ b/buildall.bat
@@ -24,7 +24,9 @@ if defined option (
   echo   -t {target-dir}    Specify the target directory where to install the bits
   echo   -p 32              Builds 32bit. Default: all
   echo   -p 64              Builds 64bit. Default: all
-  echo   -only micro        Builds only the microbits
+  echo   -only micro/all    Builds only the microbits ^(all but python and
+  echo                         ruby^) or all bits. Default: all
+  echo                        
   echo.
   goto :eof
 )
@@ -35,6 +37,12 @@ if defined option-t (
 )
 echo Using for target directory: %dest_dir%
 echo.
+
+if defined option-only (
+  set micro_all=%option-only%
+) else (
+  set micro_all="all"
+)
 
 if defined option-p (
   if "%option-p%" == "32" (
@@ -51,6 +59,7 @@ if defined option-p (
   set option-32=1
   set option-64=1
 )
+
 
 rem ----------------------------------------------------------
 rem runs all builds
@@ -118,9 +127,10 @@ mkdir %TEMP%\klayout-bits
 
 set inst_path=%~dp0
 
+echo Calling build.bat
 if defined option-32 (
-  call %inst_path%build.bat x86 msvc2017 %dest_dir%
+  call %inst_path%build.bat x86 msvc2017 %dest_dir% %micro_all%
 )
 if defined option-64 (
-  call %inst_path%build.bat x64 msvc2017 %dest_dir%
+  call %inst_path%build.bat x64 msvc2017 %dest_dir% %micro_all%
 )


### PR DESCRIPTION
Following the theme of the other pull requests, I prepared a pipeline in Azure for this.

In addition to that, I noticed that for building pymod in windows, we don't actually need python or ruby's binaries. So I created a "microbits" version of this kit as a subset. So I needed to add an option to the `buildall.bat` script:

`buildall.bat -only micro`

I uploaded a klayout-microbits.1.0.zip to bintray, to be used while building klayout pymod on windows.

Find build logs here:https://dev.azure.com/thomaslima/klayout/_build?definitionId=2